### PR TITLE
Fix java.lang.ClassCastException

### DIFF
--- a/step-by-step/http-session-support/src/main/java/com/itranswarp/jerrymouse/engine/ServletContextImpl.java
+++ b/step-by-step/http-session-support/src/main/java/com/itranswarp/jerrymouse/engine/ServletContextImpl.java
@@ -201,7 +201,6 @@ public class ServletContextImpl implements ServletContext {
         }
         Servlet servlet = null;
         try {
-            Class<? extends Servlet> clazz = createInstance(className);
             servlet = createInstance(clazz);
         } catch (ServletException e) {
             throw new RuntimeException(e);
@@ -258,7 +257,6 @@ public class ServletContextImpl implements ServletContext {
         }
         Filter filter = null;
         try {
-            Class<? extends Filter> clazz = createInstance(className);
             filter = createInstance(clazz);
         } catch (ServletException e) {
             throw new RuntimeException(e);


### PR DESCRIPTION
## Bug 描述

`public ServletRegistration.Dynamic addServlet(String name, String className)` 中，调用第一个`createInstance()`方法，会直接返回类型的实例，而不是`Class<? extends Servlet>`.

## Bug 复现

```java
public void initialize(List<Class<?>> servletClasses) {
        for (Class<?> c : servletClasses) {
                ...
                ServletRegistration.Dynamic registration = this.addServlet(AnnoUtils.getServletName(clazz), clazz.getName());
               ...
            }
        }
```

报错信息：
```bash
java.lang.ClassCastException: class com.abc.edf.engine.servlet.IndexServlet cannot be cast to class java.lang.Class 
```

## 修复

删除第一个调用`createInstance()`即可。

注：该PR只修改了其中一部分，剩下类似的章节可能都应修改。